### PR TITLE
Fix: Docker build not failing on build script fail

### DIFF
--- a/rootfs/build-scripts/bootstrap.sh
+++ b/rootfs/build-scripts/bootstrap.sh
@@ -1,15 +1,22 @@
 #!/bin/sh
 
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+executeBuildScript() {
+  sh -e "/build-scripts/${1}.sh"
+}
+
 # Update repositories info
 /build-scripts/package-manager.sh update
 /build-scripts/package-manager.sh upgrade
 
 # Setup tools
-/build-scripts/setup-s6overlay.sh
-/build-scripts/setup-shell.sh
-/build-scripts/setup-nvim.sh
-/build-scripts/setup-lazygit.sh
-/build-scripts/setup-secrets.sh
+executeBuildScript "setup-s6overlay"
+executeBuildScript "setup-shell"
+executeBuildScript "setup-nvim"
+executeBuildScript "setup-lazygit"
+executeBuildScript "setup-secrets"
 
 # Clean Up
 apt-get clean


### PR DESCRIPTION
This Pull Request:

- [x] Exists docker build on build-script fail