### PR TITLE
Fix: nvim required packages

### DIFF
--- a/rootfs/build-scripts/setup-nvim.sh
+++ b/rootfs/build-scripts/setup-nvim.sh
@@ -8,7 +8,8 @@ echo "Installing required packages..."
   git \
   python3 \
   python3-venv \
-  ripgrep
+  ripgrep \
+  tree-sitter-cli
 
 echo "Checking system architecture..."
 UNAME_OUT="$(uname)"


### PR DESCRIPTION
### :construction: Describe the changes made by this PR

- [x] Install required `tree-sitter-cli` for `tree-sitter` to work.

